### PR TITLE
Enable custom cache key

### DIFF
--- a/src/extend/aggregate.ts
+++ b/src/extend/aggregate.ts
@@ -9,7 +9,7 @@ export default function extendQuery (mongoose: Mongoose, cache: Cache): void {
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   mongoose.Aggregate.prototype.getCacheKey = function () {
-    return getKey({
+    return this._key || getKey({
       pipeline: this.pipeline()
     })
   }


### PR DESCRIPTION
I find the custom key is ignored.  The key is saved in the this._key, however it's not used in the getCacheKey.