### PR TITLE
Code Improvement: Transition to Map cache and private fields

### DIFF
--- a/src/cache/Cache.ts
+++ b/src/cache/Cache.ts
@@ -8,12 +8,12 @@ import MemoryCacheEngine from './engine/MemoryCacheEngine'
 import RedisCacheEngine from './engine/RedisCacheEngine'
 
 class CacheEngine {
-  private engine!: ICacheEngine
-  private defaultTTL: number
-  private readonly engines = ['memory', 'redis'] as const
+  #engine!: ICacheEngine
+  #defaultTTL: number
+  readonly #engines = ['memory', 'redis'] as const
 
   constructor (cacheOptions: ICacheOptions) {
-    if (!this.engines.includes(cacheOptions.engine)) {
+    if (!this.#engines.includes(cacheOptions.engine)) {
       throw new Error(`Invalid engine name: ${cacheOptions.engine}`)
     }
 
@@ -21,36 +21,36 @@ class CacheEngine {
       throw new Error(`Engine options are required for ${cacheOptions.engine} engine`)
     }
 
-    this.defaultTTL = ms(cacheOptions.defaultTTL ?? '1 minute')
+    this.#defaultTTL = ms(cacheOptions.defaultTTL ?? '1 minute')
 
     if (cacheOptions.engine === 'redis' && cacheOptions.engineOptions) {
-      this.engine = new RedisCacheEngine(cacheOptions.engineOptions)
+      this.#engine = new RedisCacheEngine(cacheOptions.engineOptions)
     }
 
     if (cacheOptions.engine === 'memory') {
-      this.engine = new MemoryCacheEngine()
+      this.#engine = new MemoryCacheEngine()
     }
   }
 
   async get (key: string): Promise<IData> {
-    return this.engine.get(key)
+    return this.#engine.get(key)
   }
 
   async set (key: string, value: Record<string, unknown> | Record<string, unknown>[], ttl: string | null): Promise<void> {
-    const actualTTL = ttl ? ms(ttl) : this.defaultTTL
-    return this.engine.set(key, value, actualTTL)
+    const actualTTL = ttl ? ms(ttl) : this.#defaultTTL
+    return this.#engine.set(key, value, actualTTL)
   }
 
   async del (key: string): Promise<void> {
-    return this.engine.del(key)
+    return this.#engine.del(key)
   }
 
   async clear (): Promise<void> {
-    return this.engine.clear()
+    return this.#engine.clear()
   }
 
   async close (): Promise<void> {
-    return this.engine.close()
+    return this.#engine.close()
   }
 }
 

--- a/src/cache/engine/MemoryCacheEngine.ts
+++ b/src/cache/engine/MemoryCacheEngine.ts
@@ -2,14 +2,14 @@ import type IData from '../../interfaces/IData'
 import type ICacheEngine from '../../interfaces/ICacheEngine'
 
 class MemoryCacheEngine implements ICacheEngine {
-  private cache: Record<string, { value: IData, expiresAt: number } | undefined>
+  #cache: Map<string, { value: IData, expiresAt: number } | undefined>
 
   constructor () {
-    this.cache = {}
+    this.#cache = new Map()
   }
 
   get (key: string): IData {
-    const item = this.cache[key]
+    const item = this.#cache.get(key)
     if (!item || item.expiresAt < Date.now()) {
       this.del(key)
       return undefined
@@ -18,16 +18,18 @@ class MemoryCacheEngine implements ICacheEngine {
   }
 
   set (key: string, value: IData, ttl = Infinity): void {
-    this.cache[key] = { value, expiresAt: Date.now() + ttl }
+    this.#cache.set(key, { 
+      value, 
+      expiresAt: Date.now() + ttl 
+    })
   }
 
   del (key: string): void {
-    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-    delete this.cache[key]
+    this.#cache.delete(key)
   }
 
   clear (): void {
-    this.cache = {}
+    this.#cache.clear()
   }
 
   close (): void {

--- a/src/cache/engine/RedisCacheEngine.ts
+++ b/src/cache/engine/RedisCacheEngine.ts
@@ -6,17 +6,17 @@ import type IData from '../../interfaces/IData'
 import type ICacheEngine from '../../interfaces/ICacheEngine'
 
 class RedisCacheEngine implements ICacheEngine {
-  private client: Redis
+  #client: Redis
 
   constructor (options: RedisOptions) {
     if (!options.keyPrefix) {
       options.keyPrefix = 'cache-mongoose:'
     }
-    this.client = new IORedis(options)
+    this.#client = new IORedis(options)
   }
 
   async get (key: string): Promise<IData> {
-    const value = await this.client.get(key)
+    const value = await this.#client.get(key)
     if (value === null) {
       return undefined
     }
@@ -35,19 +35,19 @@ class RedisCacheEngine implements ICacheEngine {
 
   async set (key: string, value: unknown, ttl = Infinity): Promise<void> {
     const serializedValue = JSON.stringify(value)
-    await this.client.setex(key, Math.ceil(ttl / 1000), serializedValue)
+    await this.#client.setex(key, Math.ceil(ttl / 1000), serializedValue)
   }
 
   async del (key: string): Promise<void> {
-    await this.client.del(key)
+    await this.#client.del(key)
   }
 
   async clear (): Promise<void> {
-    await this.client.flushdb()
+    await this.#client.flushdb()
   }
 
   async close (): Promise<void> {
-    await this.client.quit()
+    await this.#client.quit()
   }
 }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -30,38 +30,37 @@ declare module 'mongoose' {
 }
 
 class CacheMongoose {
-  // eslint-disable-next-line no-use-before-define
-  private static instance: CacheMongoose | undefined
-  private cache!: Cache
+  static #instance: CacheMongoose | undefined
+  #cache!: Cache
 
   private constructor () {
     // Private constructor to prevent external instantiation
   }
 
   public static init (mongoose: Mongoose, cacheOptions: ICacheOptions): CacheMongoose {
-    if (!this.instance) {
-      this.instance = new CacheMongoose()
-      this.instance.cache = new Cache(cacheOptions)
+    if (!this.#instance) {
+      this.#instance = new CacheMongoose()
+      this.#instance.#cache = new Cache(cacheOptions)
 
-      const cache = this.instance.cache
+      const cache = this.#instance.#cache
 
       extendQuery(mongoose, cache)
       extendAggregate(mongoose, cache)
     }
 
-    return this.instance
+    return this.#instance
   }
 
   public async clear (customKey?: string): Promise<void> {
     if (customKey != null) {
-      await this.cache.del(customKey)
+      await this.#cache.del(customKey)
     } else {
-      await this.cache.clear()
+      await this.#cache.clear()
     }
   }
 
   public async close (): Promise<void> {
-    await this.cache.close()
+    await this.#cache.close()
   }
 }
 


### PR DESCRIPTION
Just made some minor code improvements while trying to understand the code more to add some features for auto cache expiry possibly :))

- Managed to remove some Eslint ignore comments when switching to ECMAScript private fields (The added benefit of ECMAScript private fields also makes the fields not available to subclasses)
- Switched to Map instead of the plain object for memory cache engine - just thought it would be slightly cleaner. However, map can offer slightly better performance for larger caches that do frequent lookup and deletion