### PR TITLE
feat: add debug logging

### DIFF
--- a/src/cache/Cache.ts
+++ b/src/cache/Cache.ts
@@ -32,7 +32,7 @@ class CacheEngine {
       this.#engine = new MemoryCacheEngine()
     }
 
-    this.#debug = (cacheOptions.debug === true) ?? false
+    this.#debug = cacheOptions.debug === true
   }
 
   async get(key: string): Promise<IData> {

--- a/src/cache/Cache.ts
+++ b/src/cache/Cache.ts
@@ -10,6 +10,7 @@ import RedisCacheEngine from './engine/RedisCacheEngine'
 class CacheEngine {
   #engine!: ICacheEngine
   #defaultTTL: number
+  #debug: boolean;
   readonly #engines = ['memory', 'redis'] as const
 
   constructor(cacheOptions: ICacheOptions) {
@@ -30,23 +31,40 @@ class CacheEngine {
     if (cacheOptions.engine === 'memory') {
       this.#engine = new MemoryCacheEngine()
     }
+
+    this.#debug = (cacheOptions.debug === true) ?? false
   }
 
   async get(key: string): Promise<IData> {
-    return this.#engine.get(key)
+    const cacheEntry = await this.#engine.get(key)
+    if (this.#debug) {
+      const cacheHit = (cacheEntry != undefined) ? "HIT" : "MISS"
+      console.log(`[ts-cache-mongoose] GET '${key}' - ${cacheHit}`)
+    }
+    return cacheEntry
   }
 
   async set(key: string, value: Record<string, unknown> | Record<string, unknown>[], ttl: string | null): Promise<void> {
     const actualTTL = ttl ? ms(ttl) : this.#defaultTTL
-    return this.#engine.set(key, value, actualTTL)
+    await this.#engine.set(key, value, actualTTL)
+    if (this.#debug) {
+      console.log(`[ts-cache-mongoose] SET '${key}' - ttl: ${actualTTL} ms`)
+    }
+    
   }
 
   async del(key: string): Promise<void> {
-    return this.#engine.del(key)
+    await this.#engine.del(key)
+    if (this.#debug) {
+      console.log(`[ts-cache-mongoose] DEL '${key}'`)
+    }
   }
 
   async clear(): Promise<void> {
-    return this.#engine.clear()
+    await this.#engine.clear()
+    if (this.#debug) {
+      console.log(`[ts-cache-mongoose] CLEAR`)
+    }
   }
 
   async close(): Promise<void> {

--- a/src/cache/Cache.ts
+++ b/src/cache/Cache.ts
@@ -48,7 +48,7 @@ class CacheEngine {
     const actualTTL = ttl ? ms(ttl) : this.#defaultTTL
     await this.#engine.set(key, value, actualTTL)
     if (this.#debug) {
-      console.log(`[ts-cache-mongoose] SET '${key}' - ttl: ${actualTTL} ms`)
+      console.log(`[ts-cache-mongoose] SET '${key}' - ttl: ${actualTTL.toFixed(0)} ms`)
     }
   }
 

--- a/src/cache/Cache.ts
+++ b/src/cache/Cache.ts
@@ -10,7 +10,7 @@ import RedisCacheEngine from './engine/RedisCacheEngine'
 class CacheEngine {
   #engine!: ICacheEngine
   #defaultTTL: number
-  #debug: boolean;
+  #debug: boolean
   readonly #engines = ['memory', 'redis'] as const
 
   constructor(cacheOptions: ICacheOptions) {
@@ -38,7 +38,7 @@ class CacheEngine {
   async get(key: string): Promise<IData> {
     const cacheEntry = await this.#engine.get(key)
     if (this.#debug) {
-      const cacheHit = (cacheEntry != undefined) ? "HIT" : "MISS"
+      const cacheHit = (cacheEntry != undefined) ? 'HIT' : 'MISS'
       console.log(`[ts-cache-mongoose] GET '${key}' - ${cacheHit}`)
     }
     return cacheEntry
@@ -50,7 +50,6 @@ class CacheEngine {
     if (this.#debug) {
       console.log(`[ts-cache-mongoose] SET '${key}' - ttl: ${actualTTL} ms`)
     }
-    
   }
 
   async del(key: string): Promise<void> {

--- a/src/interfaces/ICacheOptions.ts
+++ b/src/interfaces/ICacheOptions.ts
@@ -4,6 +4,7 @@ interface ICacheOptions {
   engine: 'memory' | 'redis'
   engineOptions?: RedisOptions
   defaultTTL?: string
+  debug?: boolean;
 }
 
 export default ICacheOptions

--- a/src/interfaces/ICacheOptions.ts
+++ b/src/interfaces/ICacheOptions.ts
@@ -4,7 +4,7 @@ interface ICacheOptions {
   engine: 'memory' | 'redis'
   engineOptions?: RedisOptions
   defaultTTL?: string
-  debug?: boolean;
+  debug?: boolean
 }
 
 export default ICacheOptions


### PR DESCRIPTION
This PR:
- Adds a `debug` flag to the cache options which, if set, enables debug cache logging