### PR TITLE
Bump to Node >=20, ES2023, replace CacheTTL with Duration type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ npm-debug.log
 
 # In-memory mongo config
 /globalConfig.json
+
+# Claude Code
+.claude/
+CLAUDE.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,51 +1,41 @@
-# Contributing Guidelines
+# Contributing
 
-We welcome contributions from the community. Please follow these guidelines to ensure a smooth process.
-
-## Development Setup
+## Getting Started
 
 ```bash
+git clone https://github.com/ilovepixelart/ts-cache-mongoose.git
+cd ts-cache-mongoose
 npm install
 ```
 
-### Commands
+## Development
 
 ```bash
-npm run build          # Build with pkgroll
-npm test               # Run tests with vitest + coverage
-npm run type:check     # TypeScript type checking
-npm run biome          # Lint check
-npm run biome:fix      # Lint + auto-fix
+npm run type:check     # type check
+npm run biome          # lint check
+npm run biome:fix      # lint + auto-fix
+npm test               # run tests with coverage
+npm run build          # build with pkgroll
 ```
 
-### Git Hooks
+## Before Submitting a PR
 
-The project uses `simple-git-hooks`:
-- **pre-commit**: runs `npm run type:check`
-- **pre-push**: runs `npm run biome:fix`
-
-## How to Contribute
-
-1. **Start an Issue**: Before you start working on a feature or bug fix, please create an issue to discuss the best approach.
-2. **Fork the Repository**: Create a fork of the repository to work on your changes.
-3. **Create a Branch**: Create a new branch for your work.
-4. **Make Changes**: Ensure your code follows the project's coding standards.
-5. **Write Tests**: Write tests for your changes using vitest.
-6. **Commit Changes**: Commit with a clear and concise commit message.
-7. **Create a Pull Request**: Provide a detailed description of your changes.
+1. Run the full check: `npm run type:check && npm run biome && npm test && npm run build`
+2. Ensure no test regressions
+3. Follow the existing code style (Biome handles formatting)
+4. Keep changes focused — one feature or fix per PR
 
 ## Code Style
 
 - ESM (`"type": "module"`)
 - Strict TypeScript
 - Biome formatting: no semicolons, single quotes, 2-space indent
+- Arrow functions for standalone functions (no `this`)
+- No unnecessary comments or docstrings
 
-## Dependency Policy
+## Testing
 
-- Only `ioredis` in production dependencies
-- Custom implementations: `src/ms.ts` (time parsing), `src/sort-keys.ts` (key sorting)
-- Never add external deps for functionality that can be implemented in < 50 lines
-
-## Code of Conduct
-
-Please note that this project is governed by a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to adhere to it.
+- Framework: vitest
+- Database: mongodb-memory-server
+- Write tests for new features and bug fixes
+- Test behavior, not implementation details

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "aggregate"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "files": [
     "dist",

--- a/src/cache/Cache.ts
+++ b/src/cache/Cache.ts
@@ -2,7 +2,7 @@ import { ms } from '../ms'
 import { MemoryCacheEngine } from './engine/MemoryCacheEngine'
 import { RedisCacheEngine } from './engine/RedisCacheEngine'
 
-import type { CacheData, CacheEngine, CacheOptions, CacheTTL } from '../types'
+import type { CacheData, CacheEngine, CacheOptions, Duration } from '../types'
 
 export class Cache {
   readonly #engine!: CacheEngine
@@ -21,7 +21,7 @@ export class Cache {
 
     cacheOptions.defaultTTL ??= '1 minute'
 
-    this.#defaultTTL = typeof cacheOptions.defaultTTL === 'string' ? ms(cacheOptions.defaultTTL) : cacheOptions.defaultTTL
+    this.#defaultTTL = ms(cacheOptions.defaultTTL)
 
     if (cacheOptions.engine === 'redis' && cacheOptions.engineOptions) {
       this.#engine = new RedisCacheEngine(cacheOptions.engineOptions)
@@ -43,8 +43,8 @@ export class Cache {
     return cacheEntry
   }
 
-  async set(key: string, value: CacheData, ttl: CacheTTL | null): Promise<void> {
-    const givenTTL = typeof ttl === 'string' ? ms(ttl) : ttl
+  async set(key: string, value: CacheData, ttl: Duration | null): Promise<void> {
+    const givenTTL = ttl == null ? null : ms(ttl)
     const actualTTL = givenTTL ?? this.#defaultTTL
     await this.#engine.set(key, value, actualTTL)
     if (this.#debug) {

--- a/src/cache/engine/MemoryCacheEngine.ts
+++ b/src/cache/engine/MemoryCacheEngine.ts
@@ -1,6 +1,6 @@
 import { ms } from '../../ms'
 
-import type { CacheData, CacheEngine, CacheTTL } from '../../types'
+import type { CacheData, CacheEngine, Duration } from '../../types'
 
 export class MemoryCacheEngine implements CacheEngine {
   readonly #cache: Map<string, { value: CacheData; expiresAt: number } | undefined>
@@ -18,8 +18,8 @@ export class MemoryCacheEngine implements CacheEngine {
     return item.value
   }
 
-  set(key: string, value: CacheData, ttl?: CacheTTL): void {
-    const givenTTL = typeof ttl === 'string' ? ms(ttl) : ttl
+  set(key: string, value: CacheData, ttl?: Duration): void {
+    const givenTTL = ttl == null ? undefined : ms(ttl)
     const actualTTL = givenTTL ?? Number.POSITIVE_INFINITY
     this.#cache.set(key, {
       value,

--- a/src/cache/engine/RedisCacheEngine.ts
+++ b/src/cache/engine/RedisCacheEngine.ts
@@ -4,7 +4,7 @@ import { ms } from '../../ms'
 import { convertToObject } from '../../version'
 
 import type { Redis, RedisOptions } from 'ioredis'
-import type { CacheData, CacheEngine, CacheTTL } from '../../types'
+import type { CacheData, CacheEngine, Duration } from '../../types'
 
 export class RedisCacheEngine implements CacheEngine {
   readonly #client: Redis
@@ -27,9 +27,9 @@ export class RedisCacheEngine implements CacheEngine {
     }
   }
 
-  async set(key: string, value: CacheData, ttl?: CacheTTL): Promise<void> {
+  async set(key: string, value: CacheData, ttl?: Duration): Promise<void> {
     try {
-      const givenTTL = typeof ttl === 'string' ? ms(ttl) : ttl
+      const givenTTL = ttl == null ? undefined : ms(ttl)
       const actualTTL = givenTTL ?? Number.POSITIVE_INFINITY
       const serializedValue = EJSON.stringify(convertToObject(value))
       await this.#client.setex(key, Math.ceil(actualTTL / 1000), serializedValue)

--- a/src/extend/aggregate.ts
+++ b/src/extend/aggregate.ts
@@ -2,7 +2,7 @@ import { getKey } from '../key'
 
 import type { Mongoose } from 'mongoose'
 import type { Cache } from '../cache/Cache'
-import type { CacheTTL } from '../types'
+import type { Duration } from '../types'
 
 export function extendAggregate(mongoose: Mongoose, cache: Cache): void {
   const mongooseExec = mongoose.Aggregate.prototype.exec
@@ -15,24 +15,23 @@ export function extendAggregate(mongoose: Mongoose, cache: Cache): void {
     })
   }
 
-  mongoose.Aggregate.prototype.getCacheTTL = function (): CacheTTL | null {
+  mongoose.Aggregate.prototype.getDuration = function (): Duration | null {
     return this._ttl
   }
 
-  mongoose.Aggregate.prototype.cache = function (ttl?: CacheTTL, customKey?: string) {
+  mongoose.Aggregate.prototype.cache = function (ttl?: Duration, customKey?: string) {
     this._ttl = ttl ?? null
     this._key = customKey ?? null
     return this
   }
 
   mongoose.Aggregate.prototype.exec = async function (...args: []) {
-    // biome-ignore lint/suspicious/noPrototypeBuiltins: to support node 16
-    if (!Object.prototype.hasOwnProperty.call(this, '_ttl')) {
+    if (!Object.hasOwn(this, '_ttl')) {
       return mongooseExec.apply(this, args)
     }
 
     const key = this.getCacheKey()
-    const ttl = this.getCacheTTL()
+    const ttl = this.getDuration()
 
     const resultCache = await cache.get(key).catch((err: unknown) => {
       console.error(err)

--- a/src/extend/query.ts
+++ b/src/extend/query.ts
@@ -2,7 +2,7 @@ import { getKey } from '../key'
 
 import type { Mongoose } from 'mongoose'
 import type { Cache } from '../cache/Cache'
-import type { CacheTTL } from '../types'
+import type { Duration } from '../types'
 
 export function extendQuery(mongoose: Mongoose, cache: Cache): void {
   const mongooseExec = mongoose.Query.prototype.exec
@@ -29,24 +29,23 @@ export function extendQuery(mongoose: Mongoose, cache: Cache): void {
     })
   }
 
-  mongoose.Query.prototype.getCacheTTL = function (): CacheTTL | null {
+  mongoose.Query.prototype.getDuration = function (): Duration | null {
     return this._ttl
   }
 
-  mongoose.Query.prototype.cache = function (ttl?: CacheTTL, customKey?: string) {
+  mongoose.Query.prototype.cache = function (ttl?: Duration, customKey?: string) {
     this._ttl = ttl ?? null
     this._key = customKey ?? null
     return this
   }
 
   mongoose.Query.prototype.exec = async function (...args: []) {
-    // biome-ignore lint/suspicious/noPrototypeBuiltins: to support node 16
-    if (!Object.prototype.hasOwnProperty.call(this, '_ttl')) {
+    if (!Object.hasOwn(this, '_ttl')) {
       return mongooseExec.apply(this, args)
     }
 
     const key = this.getCacheKey()
-    const ttl = this.getCacheTTL()
+    const ttl = this.getDuration()
     const mongooseOptions = this.mongooseOptions()
 
     const isCount = this.op?.includes('count') ?? false

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,17 +3,17 @@ import { extendAggregate } from './extend/aggregate'
 import { extendQuery } from './extend/query'
 
 import type { Mongoose } from 'mongoose'
-import type { CacheOptions, CacheTTL } from './types'
+import type { CacheOptions, Duration } from './types'
 
 export * from './types'
 
 declare module 'mongoose' {
   interface Query<ResultType, DocType, THelpers, RawDocType> {
-    cache: (this: Query<ResultType, DocType, THelpers, RawDocType>, ttl?: CacheTTL, customKey?: string) => this
+    cache: (this: Query<ResultType, DocType, THelpers, RawDocType>, ttl?: Duration, customKey?: string) => this
     _key: string | null
     getCacheKey: (this: Query<ResultType, DocType, THelpers, RawDocType>) => string
-    _ttl: CacheTTL | null
-    getCacheTTL: (this: Query<ResultType, DocType, THelpers, RawDocType>) => CacheTTL | null
+    _ttl: Duration | null
+    getDuration: (this: Query<ResultType, DocType, THelpers, RawDocType>) => Duration | null
     op?: string
     _path?: unknown
     _fields?: unknown
@@ -22,11 +22,11 @@ declare module 'mongoose' {
   }
 
   interface Aggregate<ResultType> {
-    cache: (this: Aggregate<ResultType>, ttl?: CacheTTL, customKey?: string) => this
+    cache: (this: Aggregate<ResultType>, ttl?: Duration, customKey?: string) => this
     _key: string | null
     getCacheKey: (this: Aggregate<ResultType>) => string
-    _ttl: CacheTTL | null
-    getCacheTTL: (this: Aggregate<ResultType>) => CacheTTL | null
+    _ttl: Duration | null
+    getDuration: (this: Aggregate<ResultType>) => Duration | null
   }
 }
 

--- a/src/ms.ts
+++ b/src/ms.ts
@@ -4,52 +4,63 @@ const h = m * 60
 const d = h * 24
 const w = d * 7
 const y = d * 365.25
+const mo = y / 12
 
-// NOSONAR — regex from ms package, intentionally covers all time unit aliases
-const RE = /^(-?(?:\d+)?\.?\d+)\s*(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i
-
-const UNITS: Record<string, number> = {
-  years: y,
-  year: y,
-  yrs: y,
-  yr: y,
-  y,
-  weeks: w,
-  week: w,
-  w,
-  days: d,
-  day: d,
-  d,
-  hours: h,
-  hour: h,
-  hrs: h,
-  hr: h,
-  h,
-  minutes: m,
-  minute: m,
-  mins: m,
-  min: m,
-  m,
-  seconds: s,
-  second: s,
-  secs: s,
-  sec: s,
-  s,
+export const UNITS = {
   milliseconds: 1,
   millisecond: 1,
   msecs: 1,
   msec: 1,
   ms: 1,
-}
+  seconds: s,
+  second: s,
+  secs: s,
+  sec: s,
+  s,
+  minutes: m,
+  minute: m,
+  mins: m,
+  min: m,
+  m,
+  hours: h,
+  hour: h,
+  hrs: h,
+  hr: h,
+  h,
+  days: d,
+  day: d,
+  d,
+  weeks: w,
+  week: w,
+  w,
+  months: mo,
+  month: mo,
+  mo,
+  years: y,
+  year: y,
+  yrs: y,
+  yr: y,
+  y,
+} as const satisfies Record<string, number>
 
-export const ms = (val: string): number => {
+export type Unit = keyof typeof UNITS
+
+export type Duration = number | `${number}` | `${number}${Unit}` | `${number} ${Unit}`
+
+const unitPattern = Object.keys(UNITS)
+  .sort((a, b) => b.length - a.length)
+  .join('|')
+
+const RE = new RegExp(String.raw`^(-?(?:\d+)?\.?\d+)\s*(${unitPattern})?$`, 'i')
+
+export const ms = (val: Duration): number => {
   const str = String(val)
-  if (str.length > 100) return 0
+  if (str.length > 100) return Number.NaN
 
   const match = RE.exec(str)
-  if (!match) return 0
+  if (!match) return Number.NaN
 
   const n = Number.parseFloat(match[1] ?? '')
   const type = (match[2] ?? 'ms').toLowerCase()
-  return n * (UNITS[type] ?? 0)
+  return n * (UNITS[type as Unit] ?? 0)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,19 +1,20 @@
 import type { RedisOptions } from 'ioredis'
+import type { Duration } from './ms'
 
-export type CacheTTL = number | string
+export type { Duration }
 
 export type CacheData = Record<string, unknown> | Record<string, unknown>[] | unknown[] | number | undefined
 
 export type CacheOptions = {
   engine: 'memory' | 'redis'
   engineOptions?: RedisOptions
-  defaultTTL?: CacheTTL
+  defaultTTL?: Duration
   debug?: boolean
 }
 
 export interface CacheEngine {
   get: (key: string) => Promise<CacheData> | CacheData
-  set: (key: string, value: CacheData, ttl?: CacheTTL) => Promise<void> | void
+  set: (key: string, value: CacheData, ttl?: Duration) => Promise<void> | void
   del: (key: string) => Promise<void> | void
   clear: () => Promise<void> | void
   close: () => Promise<void> | void

--- a/tests/ms.test.ts
+++ b/tests/ms.test.ts
@@ -1,51 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { ms } from '../src/ms'
+import { ms, UNITS } from '../src/ms'
+
+const { s, m, h, d, w, mo, y } = UNITS
 
 describe('ms', () => {
-  it('should parse seconds', () => {
-    expect(ms('1s')).toBe(1000)
-    expect(ms('5 seconds')).toBe(5000)
-    expect(ms('30 sec')).toBe(30000)
-    expect(ms('1 second')).toBe(1000)
-    expect(ms('2 secs')).toBe(2000)
-  })
-
-  it('should parse minutes', () => {
-    expect(ms('1m')).toBe(60000)
-    expect(ms('5 minutes')).toBe(300000)
-    expect(ms('1 minute')).toBe(60000)
-    expect(ms('2 min')).toBe(120000)
-    expect(ms('3 mins')).toBe(180000)
-  })
-
-  it('should parse hours', () => {
-    expect(ms('1h')).toBe(3600000)
-    expect(ms('2 hours')).toBe(7200000)
-    expect(ms('1 hour')).toBe(3600000)
-    expect(ms('3 hr')).toBe(10800000)
-    expect(ms('4 hrs')).toBe(14400000)
-  })
-
-  it('should parse days', () => {
-    expect(ms('1d')).toBe(86400000)
-    expect(ms('2 days')).toBe(172800000)
-    expect(ms('1 day')).toBe(86400000)
-  })
-
-  it('should parse weeks', () => {
-    expect(ms('1w')).toBe(604800000)
-    expect(ms('2 weeks')).toBe(1209600000)
-    expect(ms('1 week')).toBe(604800000)
-  })
-
-  it('should parse years', () => {
-    expect(ms('1y')).toBe(31557600000)
-    expect(ms('1 year')).toBe(31557600000)
-    expect(ms('2 yrs')).toBe(63115200000)
-    expect(ms('1 yr')).toBe(31557600000)
-  })
-
   it('should parse milliseconds', () => {
     expect(ms('100ms')).toBe(100)
     expect(ms('500 milliseconds')).toBe(500)
@@ -54,15 +13,66 @@ describe('ms', () => {
     expect(ms('300 msecs')).toBe(300)
   })
 
+  it('should parse seconds', () => {
+    expect(ms('1s')).toBe(s)
+    expect(ms('5 seconds')).toBe(5 * s)
+    expect(ms('30 sec')).toBe(30 * s)
+    expect(ms('1 second')).toBe(s)
+    expect(ms('2 secs')).toBe(2 * s)
+  })
+
+  it('should parse minutes', () => {
+    expect(ms('1m')).toBe(m)
+    expect(ms('5 minutes')).toBe(5 * m)
+    expect(ms('1 minute')).toBe(m)
+    expect(ms('2 min')).toBe(2 * m)
+    expect(ms('3 mins')).toBe(3 * m)
+  })
+
+  it('should parse hours', () => {
+    expect(ms('1h')).toBe(h)
+    expect(ms('2 hours')).toBe(2 * h)
+    expect(ms('1 hour')).toBe(h)
+    expect(ms('3 hr')).toBe(3 * h)
+    expect(ms('4 hrs')).toBe(4 * h)
+  })
+
+  it('should parse days', () => {
+    expect(ms('1d')).toBe(d)
+    expect(ms('2 days')).toBe(2 * d)
+    expect(ms('1 day')).toBe(d)
+  })
+
+  it('should parse weeks', () => {
+    expect(ms('1w')).toBe(w)
+    expect(ms('2 weeks')).toBe(2 * w)
+    expect(ms('1 week')).toBe(w)
+  })
+
+  it('should parse months', () => {
+    expect(ms('1mo')).toBe(mo)
+    expect(ms('1 month')).toBe(mo)
+    expect(ms('2 months')).toBe(2 * mo)
+    expect(ms('6mo')).toBe(6 * mo)
+    expect(ms('0.5mo')).toBe(0.5 * mo)
+  })
+
+  it('should parse years', () => {
+    expect(ms('1y')).toBe(y)
+    expect(ms('1 year')).toBe(y)
+    expect(ms('2 yrs')).toBe(2 * y)
+    expect(ms('1 yr')).toBe(y)
+  })
+
   it('should parse decimal values', () => {
-    expect(ms('1.5h')).toBe(5400000)
-    expect(ms('0.5d')).toBe(43200000)
-    expect(ms('.5s')).toBe(500)
+    expect(ms('1.5h')).toBe(1.5 * h)
+    expect(ms('0.5d')).toBe(0.5 * d)
+    expect(ms('.5s')).toBe(0.5 * s)
   })
 
   it('should parse negative values', () => {
-    expect(ms('-1s')).toBe(-1000)
-    expect(ms('-3m')).toBe(-180000)
+    expect(ms('-1s')).toBe(-s)
+    expect(ms('-3m')).toBe(-3 * m)
   })
 
   it('should default to milliseconds without unit', () => {
@@ -71,23 +81,33 @@ describe('ms', () => {
   })
 
   it('should be case insensitive', () => {
-    expect(ms('1S')).toBe(1000)
-    expect(ms('1M')).toBe(60000)
-    expect(ms('1H')).toBe(3600000)
+    // @ts-expect-error runtime check
+    expect(ms('1S')).toBe(s)
+    // @ts-expect-error runtime check
+    expect(ms('1M')).toBe(m)
+    // @ts-expect-error runtime check
+    expect(ms('1H')).toBe(h)
   })
 
-  it('should return 0 for invalid strings', () => {
-    expect(ms('invalid')).toBe(0)
-    expect(ms('')).toBe(0)
-    expect(ms('abc123')).toBe(0)
+  it('should return NaN for invalid strings', () => {
+    // @ts-expect-error testing invalid input
+    expect(ms('invalid')).toBeNaN()
+    // @ts-expect-error testing invalid input
+    expect(ms('')).toBeNaN()
+    // @ts-expect-error testing invalid input
+    expect(ms('abc123')).toBeNaN()
   })
 
-  it('should return 0 for strings longer than 100 characters', () => {
-    expect(ms('a'.repeat(101))).toBe(0)
+  it('should return NaN for strings longer than 100 characters', () => {
+    // @ts-expect-error testing invalid input
+    expect(ms('a'.repeat(101))).toBeNaN()
   })
 
   it('should handle whitespace between number and unit', () => {
-    expect(ms('1 s')).toBe(1000)
-    expect(ms('5  minutes')).toBe(300000)
+    expect(ms('1 s')).toBe(s)
+    expect(ms('5  minutes')).toBe(5 * m)
+    expect(ms('1 mo')).toBe(mo)
+    expect(ms('1 week')).toBe(w)
+    expect(ms('1 year')).toBe(y)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "include": ["src"],
   "compilerOptions": {
-    "target": "ES2021",
-    "lib": ["ES2021"],
+    "target": "ES2023",
+    "lib": ["ES2023"],
     "types": ["node"],
     "module": "Preserve",
     "moduleResolution": "bundler",
@@ -18,7 +18,6 @@
     "experimentalDecorators": true,
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
-    "importHelpers": true,
     "isolatedModules": true,
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
- Bump engines.node from >=16 to >=20
- Bump tsconfig target/lib from ES2021 to ES2023
- Remove importHelpers (not needed with ES2023 target)
- Upgrade ms.ts: Duration type, UNITS export, regex from keys, NaN on invalid, months support
- Replace CacheTTL type with Duration across all cache engines and extensions
- Use Object.hasOwn instead of Object.prototype.hasOwnProperty.call
- Update ms tests with UNITS constants and NaN expectations
- Add CONTRIBUTING.md, .gitignore updates