### PR TITLE
Property tests, real Nest DI integration, and coverage gap fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Cache query and aggregate in mongoose using in-memory or redis
 \
 [![Socket Badge](https://badge.socket.dev/npm/package/ts-cache-mongoose)](https://socket.dev/npm/package/ts-cache-mongoose)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ilovepixelart/ts-cache-mongoose/badge)](https://securityscorecards.dev/viewer/?uri=github.com/ilovepixelart/ts-cache-mongoose)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12484/badge)](https://www.bestpractices.dev/en/projects/12484)
 
 ## Motivation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -285,12 +285,11 @@ chase:
   structurally unattainable; the score will move organically if external
   contributors join.
 
-- **`Fuzzing`** — `ts-cache-mongoose` has no parser or untrusted input
-  surface that benefits from fuzzing. The cache key generator and
-  engine code operate on mongoose-produced values inside a single
-  trusted Node process; there is no meaningful input corpus to
-  mutate. A continuous fuzzer (CIFuzz, OSS-Fuzz) would have nothing
-  to drive.
+- **`CII-Best-Practices`** — tracked at
+  [bestpractices.dev/projects/12484](https://www.bestpractices.dev/en/projects/12484).
+  The project targets the "passing" tier; "silver" and "gold" require
+  multiple reviewers and documented security-review processes that are
+  out of reach for a single-maintainer project.
 
 - **`Pinned-Dependencies`** — caps at ~8/10 due to a single structural
   exception: the `npm i ${{ matrix.mongoose-version[0] }} ${{ matrix.mongoose-version[1] }}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,12 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.11",
         "@nestjs/common": "11.1.18",
+        "@nestjs/core": "11.1.18",
+        "@nestjs/testing": "11.1.18",
         "@types/node": "25.6.0",
         "@vitest/coverage-v8": "4.1.4",
         "bson": "7.2.0",
+        "fast-check": "4.6.0",
         "mongodb-memory-server": "11.0.1",
         "mongoose": "9.4.1",
         "np": "11.0.3",
@@ -1168,6 +1171,76 @@
         }
       }
     },
+    "node_modules/@nestjs/core": {
+      "version": "11.1.18",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.18.tgz",
+      "integrity": "sha512-wR3DtGyk/LUAiPtbXDuWJJwVkWElKBY0sqnTzf9d4uM3+X18FRZhK7WFc47czsIGOdWuRsMeLYV+1Z9dO4zDEQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/opencollective": "0.4.1",
+        "fast-safe-stringify": "2.1.1",
+        "iterare": "1.2.1",
+        "path-to-regexp": "8.4.2",
+        "tslib": "2.8.1",
+        "uid": "2.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/microservices": "^11.0.0",
+        "@nestjs/platform-express": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/platform-express": {
+          "optional": true
+        },
+        "@nestjs/websockets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/testing": {
+      "version": "11.1.18",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.18.tgz",
+      "integrity": "sha512-frzwNlpBgtAzI3hp/qo57DZoRO4RMTH1wST3QUYEhRTHyfPkLpzkWz3jV/mhApXjD0yT56Ptlzn6zuYPLh87Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
+        "@nestjs/microservices": "^11.0.0",
+        "@nestjs/platform-express": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/platform-express": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1204,6 +1277,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@nuxt/opencollective": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
+      "integrity": "sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      },
+      "bin": {
+        "opencollective": "bin/opencollective.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0",
+        "npm": ">=5.10.0"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -2683,6 +2773,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3161,6 +3261,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -3184,6 +3307,13 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -5969,6 +6099,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/path-type": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
@@ -6654,6 +6795,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -91,9 +91,12 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.11",
     "@nestjs/common": "11.1.18",
+    "@nestjs/core": "11.1.18",
+    "@nestjs/testing": "11.1.18",
     "@types/node": "25.6.0",
     "@vitest/coverage-v8": "4.1.4",
     "bson": "7.2.0",
+    "fast-check": "4.6.0",
     "mongodb-memory-server": "11.0.1",
     "mongoose": "9.4.1",
     "np": "11.0.3",

--- a/tests/cache-memory.test.ts
+++ b/tests/cache-memory.test.ts
@@ -27,6 +27,17 @@ describe('cache-memory', async () => {
     await mongoose.connection.collection('users').deleteMany({})
   })
 
+  describe('singleton behavior', () => {
+    it('init() returns the same CacheMongoose instance on a second call', () => {
+      // First init happened in beforeAll; the second call hits the
+      // early-return branch in `if (!CacheMongoose.#instance)` and
+      // returns the cached instance without re-wiring the mongoose
+      // hooks. Coverage for src/index.ts line 42.
+      const second = CacheMongoose.init(mongoose, { engine: 'memory' })
+      expect(second).toBe(cache)
+    })
+  })
+
   describe('memory scenarios', () => {
     it('should use memory cache', async () => {
       const user = await UserModel.create({

--- a/tests/ms.property.test.ts
+++ b/tests/ms.property.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+
+import fc from 'fast-check'
+import { ms, UNITS, type Unit } from '../src/ms'
+
+const unitNames = Object.keys(UNITS) as Unit[]
+
+// Positive integer strings without leading zero, so the regex parses
+// them back unambiguously and Number.parseFloat round-trips the value.
+const positiveIntArb = fc.integer({ min: 1, max: 1_000_000 }).map((n) => String(n))
+
+const unitArb = fc.constantFrom(...unitNames)
+
+describe('ms — properties', () => {
+  it('never throws on any string input', () => {
+    fc.assert(
+      fc.property(fc.string(), (input) => {
+        expect(() => ms(input as never)).not.toThrow()
+      }),
+    )
+  })
+
+  it('always returns a number (finite or NaN)', () => {
+    fc.assert(
+      fc.property(fc.string(), (input) => {
+        const result = ms(input as never)
+        expect(typeof result).toBe('number')
+      }),
+    )
+  })
+
+  it('returns NaN for inputs longer than 100 characters', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 101, max: 5000 }), (length) => {
+        const tooLong = 'a'.repeat(length)
+        expect(ms(tooLong as never)).toBeNaN()
+      }),
+    )
+  })
+
+  it('parses "<integer><unit>" to the same millisecond count as the unit table says', () => {
+    fc.assert(
+      fc.property(positiveIntArb, unitArb, (num, unit) => {
+        const n = Number.parseInt(num, 10)
+        expect(ms(`${n}${unit}` as never)).toBe(n * UNITS[unit])
+      }),
+    )
+  })
+
+  it('parses "<integer> <unit>" (with space) the same way as without', () => {
+    fc.assert(
+      fc.property(positiveIntArb, unitArb, (num, unit) => {
+        expect(ms(`${num} ${unit}` as never)).toBe(ms(`${num}${unit}` as never))
+      }),
+    )
+  })
+
+  it('is case-insensitive on the unit', () => {
+    fc.assert(
+      fc.property(positiveIntArb, unitArb, (num, unit) => {
+        const lower = ms(`${num}${unit}` as never)
+        const upper = ms(`${num}${unit.toUpperCase()}` as never)
+        expect(upper).toBe(lower)
+      }),
+    )
+  })
+
+  it('defaults to milliseconds when no unit suffix is present', () => {
+    fc.assert(
+      fc.property(positiveIntArb, (num) => {
+        expect(ms(num as never)).toBe(Number.parseInt(num, 10))
+      }),
+    )
+  })
+
+  it('negates for a leading "-" sign', () => {
+    fc.assert(
+      fc.property(positiveIntArb, unitArb, (num, unit) => {
+        const positive = ms(`${num}${unit}` as never)
+        const negative = ms(`-${num}${unit}` as never)
+        expect(negative).toBe(-positive)
+      }),
+    )
+  })
+
+  it('returns NaN for unknown unit suffixes', () => {
+    fc.assert(
+      fc.property(
+        positiveIntArb,
+        fc.stringMatching(/^[a-z]{1,10}$/).filter((u) => !unitNames.includes(u as Unit) && !unitNames.some((n) => n.toLowerCase() === u)),
+        (num, bogusUnit) => {
+          const result = ms(`${num}${bogusUnit}` as never)
+          expect(result).toBeNaN()
+        },
+      ),
+    )
+  })
+
+  it('known fixed transformations match', () => {
+    expect(ms('1 second' as never)).toBe(1000)
+    expect(ms('1 minute' as never)).toBe(60_000)
+    expect(ms('1 hour' as never)).toBe(3_600_000)
+    expect(ms('1 day' as never)).toBe(86_400_000)
+    expect(ms('2 weeks' as never)).toBe(2 * 7 * 86_400_000)
+    expect(ms('60 seconds' as never)).toBe(60_000)
+    expect(ms(500 as never)).toBe(500)
+  })
+
+  it('handles decimals in the numeric portion', () => {
+    expect(ms('0.5 seconds' as never)).toBe(500)
+    expect(ms('1.5 hours' as never)).toBe(1.5 * 3_600_000)
+  })
+})

--- a/tests/nest.integration.test.ts
+++ b/tests/nest.integration.test.ts
@@ -1,0 +1,112 @@
+import 'reflect-metadata'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Test } from '@nestjs/testing'
+import { CacheModule } from '../src/nest/cache.module'
+import { CacheService } from '../src/nest/cache.service'
+
+import type { CacheOptions } from '../src/types'
+
+const initMock = vi.fn()
+
+vi.mock('../src/index', () => ({
+  default: {
+    init: (...args: unknown[]) => {
+      initMock(...args)
+      return {
+        clear: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+      }
+    },
+  },
+}))
+
+const defaultOptions = { engine: 'memory', defaultTTL: '60 seconds' } satisfies CacheOptions
+
+describe('CacheModule — real Nest DI', () => {
+  beforeEach(() => {
+    initMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('forRoot wires CacheService through the real DI container', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [CacheModule.forRoot(defaultOptions)],
+    }).compile()
+
+    const svc = moduleRef.get(CacheService)
+    expect(svc).toBeInstanceOf(CacheService)
+
+    await moduleRef.init()
+    expect(initMock).toHaveBeenCalledTimes(1)
+
+    await moduleRef.close()
+  })
+
+  it('forRootAsync resolves a sync useFactory through the real DI container', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [CacheModule.forRootAsync({ useFactory: () => defaultOptions })],
+    }).compile()
+
+    await moduleRef.init()
+    expect(initMock).toHaveBeenCalledTimes(1)
+
+    await moduleRef.close()
+  })
+
+  it('forRootAsync resolves an async useFactory through the real DI container', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        CacheModule.forRootAsync({
+          useFactory: async () => {
+            await Promise.resolve()
+            return defaultOptions
+          },
+        }),
+      ],
+    }).compile()
+
+    await moduleRef.init()
+    expect(initMock).toHaveBeenCalledTimes(1)
+
+    await moduleRef.close()
+  })
+
+  it('forRootAsync useClass calls createCacheOptions via the real container', async () => {
+    const createSpy = vi.fn().mockReturnValue(defaultOptions)
+
+    class TestFactory {
+      createCacheOptions() {
+        return createSpy()
+      }
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [CacheModule.forRootAsync({ useClass: TestFactory })],
+    }).compile()
+
+    await moduleRef.init()
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(initMock).toHaveBeenCalledWith(expect.anything(), defaultOptions)
+
+    await moduleRef.close()
+  })
+
+  it('onApplicationShutdown closes the cache via enableShutdownHooks', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [CacheModule.forRoot(defaultOptions)],
+    }).compile()
+    moduleRef.enableShutdownHooks()
+
+    await moduleRef.init()
+    const svc = moduleRef.get(CacheService)
+    const closeSpy = vi.spyOn(svc.instance, 'close')
+    await moduleRef.close()
+
+    expect(closeSpy).toHaveBeenCalled()
+  })
+})

--- a/tests/nest.test.ts
+++ b/tests/nest.test.ts
@@ -3,7 +3,14 @@ import { describe, expect, it, vi } from 'vitest'
 import { CacheModule } from '../src/nest/cache.module'
 import { CACHE_OPTIONS, CacheService } from '../src/nest/cache.service'
 
+import type { FactoryProvider, Provider } from '@nestjs/common'
 import type { CacheOptions } from '../src/types'
+
+const findFactoryProvider = (providers: Provider[], token: unknown): FactoryProvider => {
+  const hit = (providers as FactoryProvider[]).find((p) => typeof p === 'object' && p !== null && 'provide' in p && p.provide === token && 'useFactory' in p)
+  if (!hit) throw new Error(`factory provider for ${String(token)} not found`)
+  return hit
+}
 
 vi.mock('@nestjs/common', () => {
   const LoggerMock = class {
@@ -50,6 +57,14 @@ describe('CacheModule', () => {
       const optionsProvider = (result.providers as { provide: symbol; useValue: unknown }[]).find((p) => p.provide === CACHE_OPTIONS)
       expect(optionsProvider).toBeDefined()
       expect(optionsProvider?.useValue).toEqual(defaultOptions)
+    })
+
+    it('CacheService factory constructs a CacheService from CACHE_OPTIONS', () => {
+      const result = CacheModule.forRoot(defaultOptions)
+      const svcProvider = findFactoryProvider(result.providers as Provider[], CacheService)
+      expect(svcProvider.inject).toEqual([CACHE_OPTIONS])
+      const svc = (svcProvider.useFactory as (opts: typeof defaultOptions) => CacheService)(defaultOptions)
+      expect(svc).toBeInstanceOf(CacheService)
     })
   })
 
@@ -105,6 +120,46 @@ describe('CacheModule', () => {
         useFactory: () => defaultOptions,
       })
       expect(result.global).toBe(true)
+    })
+
+    it('CacheService factory constructs a CacheService from CACHE_OPTIONS', () => {
+      const result = CacheModule.forRootAsync({ useFactory: () => defaultOptions })
+      const svcProvider = findFactoryProvider(result.providers as Provider[], CacheService)
+      expect(svcProvider.inject).toEqual([CACHE_OPTIONS])
+      const svc = (svcProvider.useFactory as (opts: typeof defaultOptions) => CacheService)(defaultOptions)
+      expect(svc).toBeInstanceOf(CacheService)
+    })
+
+    it('useClass provider factory calls createCacheOptions on the injected factory instance', () => {
+      class TestFactory {
+        createCacheOptions() {
+          return defaultOptions
+        }
+      }
+      const result = CacheModule.forRootAsync({ useClass: TestFactory })
+      const optionsProvider = findFactoryProvider(result.providers as Provider[], CACHE_OPTIONS)
+      expect(optionsProvider.inject).toEqual([TestFactory])
+      const factory = new TestFactory()
+      const createSpy = vi.spyOn(factory, 'createCacheOptions')
+      const opts = (optionsProvider.useFactory as (f: TestFactory) => unknown)(factory)
+      expect(createSpy).toHaveBeenCalledTimes(1)
+      expect(opts).toEqual(defaultOptions)
+    })
+
+    it('useExisting provider factory calls createCacheOptions on the injected factory instance', () => {
+      class TestFactory {
+        createCacheOptions() {
+          return defaultOptions
+        }
+      }
+      const result = CacheModule.forRootAsync({ useExisting: TestFactory })
+      const optionsProvider = findFactoryProvider(result.providers as Provider[], CACHE_OPTIONS)
+      expect(optionsProvider.inject).toEqual([TestFactory])
+      const factory = new TestFactory()
+      const createSpy = vi.spyOn(factory, 'createCacheOptions')
+      const opts = (optionsProvider.useFactory as (f: TestFactory) => unknown)(factory)
+      expect(createSpy).toHaveBeenCalledTimes(1)
+      expect(opts).toEqual(defaultOptions)
     })
   })
 })

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+
+describe('convertToObject', () => {
+  it('passes mongoose 7+ values through unchanged', async () => {
+    vi.doMock('mongoose', () => ({ default: { version: '9.4.1' } }))
+    vi.resetModules()
+    const { convertToObject } = await import('../src/version')
+
+    expect(convertToObject({ a: 1 })).toEqual({ a: 1 })
+    expect(convertToObject([{ a: 1 }, { b: 2 }])).toEqual([{ a: 1 }, { b: 2 }])
+    expect(convertToObject(42)).toBe(42)
+    expect(convertToObject(undefined)).toBeUndefined()
+
+    vi.doUnmock('mongoose')
+  })
+
+  it('calls .toObject() on mongoose 6 documents', async () => {
+    vi.doMock('mongoose', () => ({ default: { version: '6.12.2' } }))
+    vi.resetModules()
+    const { convertToObject } = await import('../src/version')
+
+    const doc = {
+      a: 1,
+      toObject: vi.fn().mockReturnValue({ a: 1, converted: true }),
+    }
+    const result = convertToObject(doc)
+    expect(doc.toObject).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ a: 1, converted: true })
+
+    vi.doUnmock('mongoose')
+  })
+
+  it('maps arrays of mongoose 6 documents via .toObject()', async () => {
+    vi.doMock('mongoose', () => ({ default: { version: '6.12.2' } }))
+    vi.resetModules()
+    const { convertToObject } = await import('../src/version')
+
+    const docA = {
+      a: 1,
+      toObject: vi.fn().mockReturnValue({ a: 1, converted: true }),
+    }
+    const docB = {
+      b: 2,
+      toObject: vi.fn().mockReturnValue({ b: 2, converted: true }),
+    }
+    const result = convertToObject([docA, docB])
+    expect(docA.toObject).toHaveBeenCalledTimes(1)
+    expect(docB.toObject).toHaveBeenCalledTimes(1)
+    expect(result).toEqual([
+      { a: 1, converted: true },
+      { b: 2, converted: true },
+    ])
+
+    vi.doUnmock('mongoose')
+  })
+
+  it('passes plain objects through unchanged on mongoose 6 when they do not have toObject', async () => {
+    vi.doMock('mongoose', () => ({ default: { version: '6.12.2' } }))
+    vi.resetModules()
+    const { convertToObject } = await import('../src/version')
+
+    const plain = { a: 1 }
+    expect(convertToObject(plain)).toBe(plain)
+
+    vi.doUnmock('mongoose')
+  })
+
+  it('passes undefined and primitive values through on mongoose 6', async () => {
+    vi.doMock('mongoose', () => ({ default: { version: '6.12.2' } }))
+    vi.resetModules()
+    const { convertToObject } = await import('../src/version')
+
+    expect(convertToObject(undefined)).toBeUndefined()
+    expect(convertToObject(42)).toBe(42)
+
+    vi.doUnmock('mongoose')
+  })
+})


### PR DESCRIPTION
## Summary

Three related test-quality improvements plus the OpenSSF Best Practices badge now that the project is registered at [bestpractices.dev/projects/12484](https://www.bestpractices.dev/en/projects/12484).

### 1. `fast-check` property tests for `ms()` duration parser

`fast-check@4.6.0` added as a pinned devDep. New `tests/ms.property.test.ts` covers `src/ms.ts#ms()` — the most structured-input function in the repo. **11 properties:**

- **Robustness:** `ms()` never throws on any string input and always returns a number (finite or NaN)
- **Length guard:** inputs longer than 100 characters always return NaN
- **Unit parsing:** `<integer><unit>` returns `n * UNITS[unit]` exactly
- **Space tolerance:** `<integer> <unit>` (with space) is identical to the no-space form
- **Case insensitive** on the unit suffix
- **Default unit:** milliseconds when no suffix present
- **Negation:** leading `-` negates
- **Unknown units:** return NaN
- **Known-fixed transformations** (1 second → 1000, 1 minute → 60000, etc.)
- **Decimals** in the numeric portion (0.5 seconds → 500)

OpenSSF Scorecard credits `fast-check` as a JS/TS property-based testing library, so this moves **`Fuzzing` from 0/10 to 10/10** on the next scan. The accepted-findings entry for `Fuzzing` in `SECURITY.md` is removed — we earn the check now, not accept it.

### 2. Real Nest DI integration tests

`@nestjs/core` and `@nestjs/testing` added as pinned devDeps (both `11.1.18` to match the existing `@nestjs/common`). New `tests/nest.integration.test.ts` builds real `TestingModule`s via `Test.createTestingModule` and exercises the DI container:

- `forRoot` wires `CacheService` through the real DI container
- `forRootAsync` with sync `useFactory` resolves correctly
- `forRootAsync` with **async** `useFactory` resolves correctly — Nest awaits the factory
- `forRootAsync` with `useClass` instantiates the config factory and calls `createCacheOptions()`
- `onApplicationShutdown` closes the cache via `enableShutdownHooks`

Previously the nest tests inspected the `DynamicModule` shape returned by `forRoot`/`forRootAsync` without actually booting Nest. Real wiring bugs (wrong token, wrong inject order, missing export) would slip through. The integration layer catches those.

### 3. Coverage gap fixes in existing `tests/nest.test.ts`

Invoke the provider `useFactory` callbacks directly in `tests/nest.test.ts` to cover lines 18 / 37 / 61 / 71 in `src/nest/cache.module.ts` — those are the `useFactory` bodies inside `forRoot`, `forRootAsync`, `useClass`, and `useExisting`. Tests previously checked the shape of the returned providers array without calling the factories. Adds a `findFactoryProvider` helper.

**Nest functions coverage: 42% → 100%.**

### 4. `src/version.ts` `convertToObject` unit tests

New `tests/version.test.ts` mocks `mongoose.version` to cover both branches:

- **mongoose 7+ path:** plain objects, arrays, primitives, `undefined` pass through unchanged
- **mongoose 6 path:** documents with `.toObject()` get converted, arrays of mongoose 6 documents are mapped through `convertToObject` recursively, plain objects without `.toObject()` pass through

The devDep is mongoose `9.4.1`, so the mongoose-6 branch (lines 9-13) was never executed under the test runner before. Uses `vi.doMock` + `vi.resetModules` to swap in a fake mongoose version per test.

**`src/version.ts` lines 50% → 100%, branches 10% → 100%.**

### 5. `src/index.ts` second-init coverage

Singleton-behavior test added in `tests/cache-memory.test.ts`: calls `CacheMongoose.init()` a second time and asserts it returns the same instance. Covers the early-return branch in `if (!CacheMongoose.#instance)` on line 42, which tests never hit before because they only called `init()` once in `beforeAll`.

**`src/index.ts` branches 75% → 100%.**

### 6. OpenSSF Best Practices badge

Added to README row 2 next to Socket and Scorecard. `SECURITY.md`'s accepted-findings section gains a `CII-Best-Practices` entry pointing at project 12484 with the "passing tier" cap rationale.

## Coverage delta

| Metric | Before | After |
|---|---|---|
| Statements | 92.41% | **96.42%** (+4.0) |
| Branches | 86.25% | **93.89%** (+7.6) |
| Functions | 85.24% | **93.44%** (+8.2) |
| Lines | 92.45% | **96.22%** (+3.8) |
| Test files | 8 | **11** |
| Tests | 77 | **103** (+26) |

## Test plan

- [x] `npm ci`
- [x] `npm audit` — 0 vulnerabilities
- [x] `npm run type:check`
- [x] `npm run type:check:tests`
- [x] `npm run biome`
- [x] `npm run build`
- [x] `npm test` — **103 / 103 passing**

## Expected Scorecard impact

On the next scan after this merges:
- **Fuzzing** 0/10 → **10/10** (fast-check property tests)
- **CII-Best-Practices** 0/10 → **5/10** (passing tier via 12484)

Overall moves from 7.x toward **~8.2**.