### PR TITLE
Add onError callback option for cache engine failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ const books = await Book.aggregate([
 ]).cache('1 minute').exec()
 ```
 
+### Custom error handling
+
+By default, cache engine failures (Redis disconnects, serialization errors, etc.) are logged via `console.error` and the query falls through to the database. Pass an `onError` callback to route them somewhere else — e.g. a structured logger, Sentry, or a metric counter:
+
+```typescript
+cache.init(mongoose, {
+  engine: 'redis',
+  defaultTTL: '60 seconds',
+  engineOptions: { host: 'localhost', port: 6379 },
+  onError: (error) => {
+    logger.warn({ err: error }, 'cache engine failure')
+  },
+})
+```
+
+The callback receives the raw `Error`. Cache reads and writes never throw — a failing engine degrades to a cache miss.
+
 ### Cache invalidation
 
 ```typescript

--- a/src/cache/Cache.ts
+++ b/src/cache/Cache.ts
@@ -8,6 +8,7 @@ export class Cache {
   readonly #engine!: CacheEngine
   readonly #defaultTTL: number
   readonly #debug: boolean
+  readonly #onError: (error: Error) => void
   readonly #engines = ['memory', 'redis'] as const
 
   constructor(cacheOptions: CacheOptions) {
@@ -22,9 +23,10 @@ export class Cache {
     cacheOptions.defaultTTL ??= '1 minute'
 
     this.#defaultTTL = ms(cacheOptions.defaultTTL)
+    this.#onError = cacheOptions.onError ?? console.error
 
     if (cacheOptions.engine === 'redis' && cacheOptions.engineOptions) {
-      this.#engine = new RedisCacheEngine(cacheOptions.engineOptions)
+      this.#engine = new RedisCacheEngine(cacheOptions.engineOptions, this.#onError)
     }
 
     if (cacheOptions.engine === 'memory') {
@@ -32,6 +34,10 @@ export class Cache {
     }
 
     this.#debug = cacheOptions.debug === true
+  }
+
+  get onError(): (error: Error) => void {
+    return this.#onError
   }
 
   async get(key: string): Promise<CacheData> {

--- a/src/cache/engine/RedisCacheEngine.ts
+++ b/src/cache/engine/RedisCacheEngine.ts
@@ -8,10 +8,12 @@ import type { CacheData, CacheEngine, Duration } from '../../types'
 
 export class RedisCacheEngine implements CacheEngine {
   readonly #client: Redis
+  readonly #onError: (error: Error) => void
 
-  constructor(options: RedisOptions) {
+  constructor(options: RedisOptions, onError: (error: Error) => void) {
     options.keyPrefix ??= 'cache-mongoose:'
     this.#client = new IORedis(options)
+    this.#onError = onError
   }
 
   async get(key: string): Promise<CacheData> {
@@ -22,7 +24,7 @@ export class RedisCacheEngine implements CacheEngine {
       }
       return EJSON.parse(value) as CacheData
     } catch (err) {
-      console.error(err)
+      this.#onError(err as Error)
       return undefined
     }
   }
@@ -41,7 +43,7 @@ export class RedisCacheEngine implements CacheEngine {
       const serializedValue = EJSON.stringify(converted)
       await this.#client.setex(key, Math.ceil(actualTTL / 1000), serializedValue)
     } catch (err) {
-      console.error(err)
+      this.#onError(err as Error)
     }
   }
 

--- a/src/extend/aggregate.ts
+++ b/src/extend/aggregate.ts
@@ -34,7 +34,7 @@ export function extendAggregate(mongoose: Mongoose, cache: Cache): void {
     const ttl = this.getDuration()
 
     const resultCache = await cache.get(key).catch((err: unknown) => {
-      console.error(err)
+      cache.onError(err as Error)
     })
 
     if (resultCache) {
@@ -43,7 +43,7 @@ export function extendAggregate(mongoose: Mongoose, cache: Cache): void {
 
     const result = (await mongooseExec.call(this)) as Record<string, unknown>[] | Record<string, unknown>
     await cache.set(key, result, ttl).catch((err: unknown) => {
-      console.error(err)
+      cache.onError(err as Error)
     })
 
     return result

--- a/src/extend/query.ts
+++ b/src/extend/query.ts
@@ -53,7 +53,7 @@ export function extendQuery(mongoose: Mongoose, cache: Cache): void {
     const model = this.model.modelName
 
     const resultCache = await cache.get(key).catch((err: unknown) => {
-      console.error(err)
+      cache.onError(err as Error)
     })
 
     if (resultCache) {
@@ -73,7 +73,7 @@ export function extendQuery(mongoose: Mongoose, cache: Cache): void {
 
     const result = (await mongooseExec.call(this)) as Record<string, unknown>[] | Record<string, unknown>
     await cache.set(key, result, ttl).catch((err: unknown) => {
-      console.error(err)
+      cache.onError(err as Error)
     })
 
     return result

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type CacheOptions = {
   engineOptions?: RedisOptions
   defaultTTL?: Duration
   debug?: boolean
+  onError?: (error: Error) => void
 }
 
 export interface CacheEngine {

--- a/tests/cache-on-error.test.ts
+++ b/tests/cache-on-error.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getMock = vi.fn()
+const setexMock = vi.fn()
+const delMock = vi.fn()
+const flushdbMock = vi.fn()
+const quitMock = vi.fn()
+
+vi.mock('ioredis', () => {
+  class FakeRedis {
+    get = getMock
+    setex = setexMock
+    del = delMock
+    flushdb = flushdbMock
+    quit = quitMock
+  }
+  return { default: FakeRedis }
+})
+
+const { Cache } = await import('../src/cache/Cache')
+const { RedisCacheEngine } = await import('../src/cache/engine/RedisCacheEngine')
+
+describe('onError callback', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    setexMock.mockReset()
+    delMock.mockReset()
+    flushdbMock.mockReset()
+    quitMock.mockReset()
+  })
+
+  it('Cache#onError defaults to console.error', () => {
+    const cache = new Cache({ engine: 'memory' })
+    expect(cache.onError).toBe(console.error)
+  })
+
+  it('Cache#onError returns the user-supplied callback', () => {
+    const onError = vi.fn()
+    const cache = new Cache({ engine: 'memory', onError })
+    expect(cache.onError).toBe(onError)
+  })
+
+  it('Cache wires onError into RedisCacheEngine so get() failures are forwarded', async () => {
+    const onError = vi.fn()
+    const cache = new Cache({
+      engine: 'redis',
+      engineOptions: { host: '127.0.0.1', port: 6379 },
+      onError,
+    })
+    const boom = new Error('get failed')
+    getMock.mockRejectedValueOnce(boom)
+    const result = await cache.get('missing')
+    expect(result).toBeUndefined()
+    expect(onError).toHaveBeenCalledWith(boom)
+  })
+
+  it('RedisCacheEngine forwards set() failures to the supplied callback', async () => {
+    const onError = vi.fn()
+    const engine = new RedisCacheEngine({ host: '127.0.0.1', port: 6379 }, onError)
+    const boom = new Error('setex failed')
+    setexMock.mockRejectedValueOnce(boom)
+    await engine.set('k', { a: 1 }, '1 minute')
+    expect(onError).toHaveBeenCalledWith(boom)
+  })
+
+  it('RedisCacheEngine.set() skips the write and does not call onError when the value converts to undefined', async () => {
+    const onError = vi.fn()
+    const engine = new RedisCacheEngine({ host: '127.0.0.1', port: 6379 }, onError)
+    await engine.set('k', undefined, '1 minute')
+    expect(setexMock).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+  })
+})

--- a/tests/cache-options.test.ts
+++ b/tests/cache-options.test.ts
@@ -80,4 +80,17 @@ describe('Cache class tests', () => {
 
     await cache.close()
   })
+
+  describe('onError option', () => {
+    it('defaults to console.error when no callback is provided', () => {
+      const cache = new Cache({ engine: 'memory' })
+      expect(cache.onError).toBe(console.error)
+    })
+
+    it('exposes the user-supplied callback via the onError getter', () => {
+      const onError = vi.fn()
+      const cache = new Cache({ engine: 'memory', onError })
+      expect(cache.onError).toBe(onError)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- New `CacheOptions.onError` callback receives engine failures (Redis disconnects, EJSON parse errors, etc.) so consumers can route them into a structured logger, Sentry, or a metric instead of `console.error`.
- Default behavior is unchanged — when no callback is supplied, errors go to `console.error` exactly as before. No caller code needs to change.
- `RedisCacheEngine` now takes the callback through its constructor, and `extendQuery` / `extendAggregate` route `cache.get` / `cache.set` rejections through `cache.onError` instead of calling `console.error` directly.
- Cache reads and writes still never throw — a failing engine continues to degrade to a cache miss. The callback is purely observational.

## Test plan

- [x] `tests/cache-on-error.test.ts` — new suite mocks `ioredis` to exercise all three error paths (RedisCacheEngine `get` / `set`, Cache-level plumbing) and the `undefined` skip-write branch.
- [x] `tests/cache-options.test.ts` — asserts default `console.error` binding and that the user-supplied callback is exposed via `Cache#onError`.
- [x] `npm run biome` clean.
- [x] `npm run type:check` and `npm run type:check:tests` clean.
- [x] Unit test sweep green: 83/83 across 9 files.
- [ ] CI: full matrix (mongoose 6.12.2 / 7.6.4 / 8.23.0 / 9.4.1), CodeQL, Sonar, Socket, Snyk.