### PR TITLE
Harden cache against DoS, non-positive TTL, and proto-pollution regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,36 @@ const books = await Book.aggregate([
 ]).cache('1 minute').exec()
 ```
 
+### Bounded in-memory cache
+
+The in-memory engine is unbounded by default. For workloads where query keys are driven by user input (search, filters, pagination), cap the cache so a caller generating unique cache keys cannot grow the map without limit. Two bounds are available and can be combined — eviction is LRU, and whichever bound is hit first triggers it:
+
+```typescript
+cache.init(mongoose, {
+  engine: 'memory',
+  defaultTTL: '60 seconds',
+  maxEntries: 10_000,          // cap by entry count
+  maxBytes: 50 * 1024 * 1024,  // cap by serialized bytes (50 MB)
+})
+```
+
+`maxBytes` measures entry size via `node:v8.serialize(value).byteLength` by default — handles circular references (mongoose `populate` parent-refs), single C++ call per `set`, works on Node / Bun / Deno. Provide your own `sizeCalculation` callback if you want an O(1) estimate instead:
+
+```typescript
+cache.init(mongoose, {
+  engine: 'memory',
+  maxBytes: 50 * 1024 * 1024,
+  sizeCalculation: (value) => {
+    if (Array.isArray(value)) return value.length * 512
+    return 512
+  },
+})
+```
+
+Eviction is soft: the just-written entry is never dropped, even if its own size exceeds `maxBytes`. Everything older gets evicted until both bounds are satisfied (or only the new entry remains).
+
+Both options are ignored for the Redis engine — use Redis's own `maxmemory` + `maxmemory-policy` instead.
+
 ### Custom error handling
 
 By default, cache engine failures (Redis disconnects, serialization errors, etc.) are logged via `console.error` and the query falls through to the database. Pass an `onError` callback to route them somewhere else — e.g. a structured logger, Sentry, or a metric counter:

--- a/src/cache/Cache.ts
+++ b/src/cache/Cache.ts
@@ -30,7 +30,11 @@ export class Cache {
     }
 
     if (cacheOptions.engine === 'memory') {
-      this.#engine = new MemoryCacheEngine()
+      this.#engine = new MemoryCacheEngine({
+        maxEntries: cacheOptions.maxEntries,
+        maxBytes: cacheOptions.maxBytes,
+        sizeCalculation: cacheOptions.sizeCalculation,
+      })
     }
 
     this.#debug = cacheOptions.debug === true
@@ -52,6 +56,12 @@ export class Cache {
   async set(key: string, value: CacheData, ttl: Duration | null): Promise<void> {
     const givenTTL = ttl == null ? null : ms(ttl)
     const actualTTL = givenTTL ?? this.#defaultTTL
+    if (Number.isNaN(actualTTL) || actualTTL <= 0) {
+      if (this.#debug) {
+        console.log(`[ts-cache-mongoose] SET '${key}' - skipped (non-positive ttl: ${String(actualTTL)} ms)`)
+      }
+      return
+    }
     await this.#engine.set(key, value, actualTTL)
     if (this.#debug) {
       console.log(`[ts-cache-mongoose] SET '${key}' - ttl: ${actualTTL.toFixed(0)} ms`)

--- a/src/cache/engine/MemoryCacheEngine.ts
+++ b/src/cache/engine/MemoryCacheEngine.ts
@@ -1,38 +1,97 @@
+import { serialize } from 'node:v8'
 import { ms } from '../../ms'
 
 import type { CacheData, CacheEngine, Duration } from '../../types'
 
-export class MemoryCacheEngine implements CacheEngine {
-  readonly #cache: Map<string, { value: CacheData; expiresAt: number } | undefined>
+type Entry = { value: CacheData; expiresAt: number; bytes: number }
 
-  constructor() {
+export type MemoryCacheEngineOptions = {
+  maxEntries?: number | undefined
+  maxBytes?: number | undefined
+  sizeCalculation?: ((value: CacheData) => number) | undefined
+}
+
+// Default sizer: v8.serialize handles circular references (mongoose
+// populate results sometimes carry parent back-refs), works in Node /
+// Bun / Deno, and does the walk in a single C++ call. Consumers can
+// override with `sizeCalculation` when they know their payload shape
+// well enough to return an O(1) estimate.
+const defaultSizer = (value: CacheData): number => serialize(value).byteLength
+
+export class MemoryCacheEngine implements CacheEngine {
+  readonly #cache: Map<string, Entry>
+  readonly #maxEntries: number
+  readonly #maxBytes: number
+  readonly #sizeOf: (value: CacheData) => number
+  #totalBytes: number
+
+  constructor(options?: MemoryCacheEngineOptions) {
     this.#cache = new Map()
+    this.#maxEntries = options?.maxEntries != null && options.maxEntries > 0 ? options.maxEntries : Number.POSITIVE_INFINITY
+    this.#maxBytes = options?.maxBytes != null && options.maxBytes > 0 ? options.maxBytes : Number.POSITIVE_INFINITY
+    this.#sizeOf = options?.sizeCalculation ?? defaultSizer
+    this.#totalBytes = 0
+  }
+
+  get totalBytes(): number {
+    return this.#totalBytes
+  }
+
+  get size(): number {
+    return this.#cache.size
   }
 
   get(key: string): CacheData {
     const item = this.#cache.get(key)
-    if (!item || item.expiresAt < Date.now()) {
-      this.del(key)
+    if (!item) return undefined
+    if (item.expiresAt < Date.now()) {
+      this.#cache.delete(key)
+      this.#totalBytes -= item.bytes
       return undefined
     }
+    // LRU touch: move entry to the end of insertion order so recently
+    // read keys outlive stale ones under eviction pressure.
+    this.#cache.delete(key)
+    this.#cache.set(key, item)
     return item.value
   }
 
   set(key: string, value: CacheData, ttl?: Duration): void {
     const givenTTL = ttl == null ? undefined : ms(ttl)
     const actualTTL = givenTTL ?? Number.POSITIVE_INFINITY
-    this.#cache.set(key, {
-      value,
-      expiresAt: Date.now() + actualTTL,
-    })
+
+    const existing = this.#cache.get(key)
+    if (existing) {
+      this.#cache.delete(key)
+      this.#totalBytes -= existing.bytes
+    }
+
+    const bytes = this.#sizeOf(value)
+    this.#cache.set(key, { value, expiresAt: Date.now() + actualTTL, bytes })
+    this.#totalBytes += bytes
+
+    // Soft cap: the just-written entry is never evicted. If either
+    // bound is exceeded, drop LRU entries until both are satisfied or
+    // only the new entry remains.
+    while ((this.#cache.size > this.#maxEntries || this.#totalBytes > this.#maxBytes) && this.#cache.size > 1) {
+      const oldestKey = this.#cache.keys().next().value
+      if (oldestKey === undefined || oldestKey === key) break
+      const oldest = this.#cache.get(oldestKey)
+      this.#cache.delete(oldestKey)
+      if (oldest) this.#totalBytes -= oldest.bytes
+    }
   }
 
   del(key: string): void {
+    const item = this.#cache.get(key)
+    if (!item) return
     this.#cache.delete(key)
+    this.#totalBytes -= item.bytes
   }
 
   clear(): void {
     this.#cache.clear()
+    this.#totalBytes = 0
   }
 
   close(): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,9 @@ export type CacheOptions = {
   defaultTTL?: Duration
   debug?: boolean
   onError?: (error: Error) => void
+  maxEntries?: number
+  maxBytes?: number
+  sizeCalculation?: (value: CacheData) => number
 }
 
 export interface CacheEngine {

--- a/tests/cache-ttl-guard.test.ts
+++ b/tests/cache-ttl-guard.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Cache } from '../src/cache/Cache'
+import { MemoryCacheEngine } from '../src/cache/engine/MemoryCacheEngine'
+
+describe('Cache.set non-positive TTL guard', () => {
+  it('does not touch the engine when actualTTL is 0', async () => {
+    const cache = new Cache({ engine: 'memory' })
+    const spy = vi.spyOn(MemoryCacheEngine.prototype, 'set')
+    await cache.set('k', { a: 1 }, '0 seconds')
+    expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
+  it('does not touch the engine when actualTTL is negative', async () => {
+    const cache = new Cache({ engine: 'memory' })
+    const spy = vi.spyOn(MemoryCacheEngine.prototype, 'set')
+    await cache.set('k', { a: 1 }, '-1 minute')
+    expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
+  it('does not touch the engine when the duration parses to NaN', async () => {
+    const cache = new Cache({ engine: 'memory' })
+    const spy = vi.spyOn(MemoryCacheEngine.prototype, 'set')
+    // biome-ignore lint/suspicious/noExplicitAny: exercising runtime guard with garbage input
+    await cache.set('k', { a: 1 }, 'nonsense' as any)
+    expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
+  it('still writes when the TTL is healthy', async () => {
+    const cache = new Cache({ engine: 'memory' })
+    const spy = vi.spyOn(MemoryCacheEngine.prototype, 'set')
+    await cache.set('k', { a: 1 }, '30 seconds')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith('k', { a: 1 }, 30000)
+    spy.mockRestore()
+  })
+
+  it('falls back to defaultTTL when ttl is null', async () => {
+    const cache = new Cache({ engine: 'memory', defaultTTL: '45 seconds' })
+    const spy = vi.spyOn(MemoryCacheEngine.prototype, 'set')
+    await cache.set('k', { a: 1 }, null)
+    expect(spy).toHaveBeenCalledWith('k', { a: 1 }, 45000)
+    spy.mockRestore()
+  })
+
+  it('still writes via the real engine end-to-end after the guard is satisfied', async () => {
+    const cache = new Cache({ engine: 'memory' })
+    await cache.set('alive', { hello: 'world' }, '1 minute')
+    expect(await cache.get('alive')).toEqual({ hello: 'world' })
+  })
+})

--- a/tests/memory-bound.test.ts
+++ b/tests/memory-bound.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+
+import { Cache } from '../src/cache/Cache'
+import { MemoryCacheEngine } from '../src/cache/engine/MemoryCacheEngine'
+
+describe('MemoryCacheEngine bounded capacity', () => {
+  describe('entry bound', () => {
+    it('is unbounded by default so existing callers are unaffected', () => {
+      const engine = new MemoryCacheEngine()
+      for (let i = 0; i < 2000; i++) {
+        engine.set(`k${i}`, { i }, '1 hour')
+      }
+      expect(engine.get('k0')).toEqual({ i: 0 })
+      expect(engine.get('k1999')).toEqual({ i: 1999 })
+    })
+
+    it('ignores non-positive maxEntries and stays unbounded', () => {
+      const engine = new MemoryCacheEngine({ maxEntries: 0 })
+      for (let i = 0; i < 10; i++) {
+        engine.set(`k${i}`, { i }, '1 hour')
+      }
+      expect(engine.get('k0')).toEqual({ i: 0 })
+      expect(engine.get('k9')).toEqual({ i: 9 })
+    })
+
+    it('evicts the oldest entry once the bound is exceeded', () => {
+      const engine = new MemoryCacheEngine({ maxEntries: 3 })
+      engine.set('a', { v: 1 }, '1 hour')
+      engine.set('b', { v: 2 }, '1 hour')
+      engine.set('c', { v: 3 }, '1 hour')
+      engine.set('d', { v: 4 }, '1 hour')
+      expect(engine.get('a')).toBeUndefined()
+      expect(engine.get('b')).toEqual({ v: 2 })
+      expect(engine.get('c')).toEqual({ v: 3 })
+      expect(engine.get('d')).toEqual({ v: 4 })
+    })
+
+    it('get() promotes the touched key so LRU order, not FIFO, drives eviction', () => {
+      const engine = new MemoryCacheEngine({ maxEntries: 3 })
+      engine.set('a', { v: 1 }, '1 hour')
+      engine.set('b', { v: 2 }, '1 hour')
+      engine.set('c', { v: 3 }, '1 hour')
+      engine.get('a')
+      engine.set('d', { v: 4 }, '1 hour')
+      expect(engine.get('a')).toEqual({ v: 1 })
+      expect(engine.get('b')).toBeUndefined()
+      expect(engine.get('c')).toEqual({ v: 3 })
+      expect(engine.get('d')).toEqual({ v: 4 })
+    })
+
+    it('repeatedly re-setting the same key does not grow the store past the bound', () => {
+      const engine = new MemoryCacheEngine({ maxEntries: 5 })
+      for (let i = 0; i < 100; i++) {
+        engine.set('k', { i }, '1 hour')
+      }
+      expect(engine.size).toBe(1)
+      expect(engine.get('k')).toEqual({ i: 99 })
+    })
+
+    it('Cache forwards maxEntries to the memory engine', async () => {
+      const cache = new Cache({ engine: 'memory', maxEntries: 2 })
+      await cache.set('a', { v: 1 }, '1 hour')
+      await cache.set('b', { v: 2 }, '1 hour')
+      await cache.set('c', { v: 3 }, '1 hour')
+      expect(await cache.get('a')).toBeUndefined()
+      expect(await cache.get('b')).toEqual({ v: 2 })
+      expect(await cache.get('c')).toEqual({ v: 3 })
+    })
+  })
+
+  describe('byte bound', () => {
+    const fixedSizer = (_: unknown): number => 100
+
+    it('defaults to v8.serialize so payload shape drives total bytes', () => {
+      const engine = new MemoryCacheEngine({ maxBytes: 1_000_000 })
+      engine.set('a', { hello: 'world' }, '1 hour')
+      expect(engine.totalBytes).toBeGreaterThan(0)
+      expect(engine.totalBytes).toBeLessThan(200)
+    })
+
+    it('tracks total bytes across set/del/clear', () => {
+      const engine = new MemoryCacheEngine({ sizeCalculation: fixedSizer })
+      engine.set('a', { v: 1 }, '1 hour')
+      engine.set('b', { v: 2 }, '1 hour')
+      expect(engine.totalBytes).toBe(200)
+      engine.del('a')
+      expect(engine.totalBytes).toBe(100)
+      engine.clear()
+      expect(engine.totalBytes).toBe(0)
+    })
+
+    it('replacing an existing key does not double-count its bytes', () => {
+      const engine = new MemoryCacheEngine({ sizeCalculation: fixedSizer })
+      engine.set('k', { v: 1 }, '1 hour')
+      engine.set('k', { v: 2 }, '1 hour')
+      engine.set('k', { v: 3 }, '1 hour')
+      expect(engine.totalBytes).toBe(100)
+      expect(engine.size).toBe(1)
+    })
+
+    it('evicts LRU entries until totalBytes is under maxBytes', () => {
+      const engine = new MemoryCacheEngine({ maxBytes: 250, sizeCalculation: fixedSizer })
+      engine.set('a', { v: 1 }, '1 hour')
+      engine.set('b', { v: 2 }, '1 hour')
+      engine.set('c', { v: 3 }, '1 hour')
+      // After inserting 'c', totalBytes = 300, evict 'a'. totalBytes = 200.
+      expect(engine.get('a')).toBeUndefined()
+      expect(engine.get('b')).toEqual({ v: 2 })
+      expect(engine.get('c')).toEqual({ v: 3 })
+      expect(engine.totalBytes).toBe(200)
+    })
+
+    it('soft cap: a single oversized entry is kept and everything older is evicted', () => {
+      const engine = new MemoryCacheEngine({
+        maxBytes: 150,
+        sizeCalculation: (v) => (v != null && typeof v === 'object' && 'huge' in v ? 10_000 : 100),
+      })
+      engine.set('a', { v: 1 }, '1 hour')
+      engine.set('b', { huge: true }, '1 hour')
+      // 'a' evicted to make room for the oversized entry; 'b' stays
+      // because we never drop the just-written entry.
+      expect(engine.get('a')).toBeUndefined()
+      expect(engine.get('b')).toEqual({ huge: true })
+      expect(engine.size).toBe(1)
+    })
+
+    it('expired entries evicted via get() decrement totalBytes', () => {
+      const engine = new MemoryCacheEngine({ sizeCalculation: fixedSizer })
+      engine.set('short', { v: 1 }, '1 millisecond')
+      expect(engine.totalBytes).toBe(100)
+      const deadline = Date.now() + 20
+      while (Date.now() < deadline) {
+        /* spin briefly */
+      }
+      expect(engine.get('short')).toBeUndefined()
+      expect(engine.totalBytes).toBe(0)
+    })
+
+    it('Cache forwards maxBytes and sizeCalculation to the memory engine', async () => {
+      const cache = new Cache({
+        engine: 'memory',
+        maxBytes: 250,
+        sizeCalculation: fixedSizer,
+      })
+      await cache.set('a', { v: 1 }, '1 hour')
+      await cache.set('b', { v: 2 }, '1 hour')
+      await cache.set('c', { v: 3 }, '1 hour')
+      expect(await cache.get('a')).toBeUndefined()
+      expect(await cache.get('b')).toEqual({ v: 2 })
+      expect(await cache.get('c')).toEqual({ v: 3 })
+    })
+
+    it('enforces whichever bound is hit first when both are set', () => {
+      const engine = new MemoryCacheEngine({
+        maxEntries: 10,
+        maxBytes: 200,
+        sizeCalculation: fixedSizer,
+      })
+      engine.set('a', { v: 1 }, '1 hour')
+      engine.set('b', { v: 2 }, '1 hour')
+      engine.set('c', { v: 3 }, '1 hour')
+      // maxBytes (200) is hit before maxEntries (10).
+      expect(engine.size).toBe(2)
+      expect(engine.get('a')).toBeUndefined()
+    })
+  })
+})

--- a/tests/proto-pollution.test.ts
+++ b/tests/proto-pollution.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { EJSON } from 'bson'
+
+// Regression test: attacker-controlled payloads read from Redis can pass
+// through bson's EJSON.parse without polluting Object.prototype. We depend
+// on this every time we rehydrate cached query results from an engine the
+// library does not own (Redis can be shared infra, MITM'd, or outright
+// compromised). If a future bson release regresses to manual
+// `result[key] = ...` during reviver handling, __proto__ assignment would
+// start walking up the prototype chain and pollute the base Object — this
+// test locks that assumption in place.
+
+describe('EJSON.parse prototype pollution regression', () => {
+  afterEach(() => {
+    // Defence in depth: make sure no earlier assertion accidentally left
+    // state on Object.prototype that would mask a regression in a later
+    // test in the same process.
+    // biome-ignore lint/suspicious/noExplicitAny: inspecting the global prototype
+    const proto = Object.prototype as any
+    delete proto.polluted
+    delete proto.polluted2
+    delete proto.polluted3
+  })
+
+  it('does not pollute Object.prototype via a top-level __proto__ key', () => {
+    const payload = '{"__proto__": {"polluted": "yes"}, "normal": 1}'
+    EJSON.parse(payload)
+    // biome-ignore lint/suspicious/noExplicitAny: reading an expando off the global prototype
+    expect(({} as any).polluted).toBeUndefined()
+    // biome-ignore lint/suspicious/noExplicitAny: inspecting the global prototype
+    expect((Object.prototype as any).polluted).toBeUndefined()
+  })
+
+  it('does not pollute Object.prototype via a nested __proto__ key', () => {
+    const payload = '{"inner": {"__proto__": {"polluted2": "yes"}}}'
+    EJSON.parse(payload)
+    // biome-ignore lint/suspicious/noExplicitAny: reading an expando off the global prototype
+    expect(({} as any).polluted2).toBeUndefined()
+  })
+
+  it('does not pollute Object.prototype via a constructor.prototype path', () => {
+    const payload = '{"constructor": {"prototype": {"polluted3": "yes"}}}'
+    EJSON.parse(payload)
+    // biome-ignore lint/suspicious/noExplicitAny: reading an expando off the global prototype
+    expect(({} as any).polluted3).toBeUndefined()
+  })
+
+  it('ignores a poisoned cached payload when hydrated into a plain object', () => {
+    // Mirrors the code path taken by extendQuery/extendAggregate: the raw
+    // JSON string lives in Redis, we run it through EJSON.parse, and the
+    // result is then spread into consumer code. None of that should leak
+    // into Object.prototype.
+    const poisoned = '{"__proto__": {"polluted": "leaked"}, "data": [{"a": 1}]}'
+    const rehydrated = EJSON.parse(poisoned) as Record<string, unknown>
+    const fresh: Record<string, unknown> = {}
+    Object.assign(fresh, rehydrated)
+    // biome-ignore lint/suspicious/noExplicitAny: reading an expando off the global prototype
+    expect(({} as any).polluted).toBeUndefined()
+    expect(fresh.data).toEqual([{ a: 1 }])
+  })
+})


### PR DESCRIPTION
## Summary

Three independent hardening changes that close real attack surfaces against the library when it runs in front of user-facing queries. Stacked on top of #350 (onError callback) — rebase cleanly once that merges.

### 1. Bound the in-memory engine by entries and/or bytes

`MemoryCacheEngine` was unbounded. A caller generating unique cache keys (queries parameterised by user input — search, filters, pagination) could grow the map until the process OOMs. Two new optional fields on `CacheOptions`:

- `maxEntries?: number` — hard cap on entry count.
- `maxBytes?: number` — cap on total serialized bytes.
- `sizeCalculation?: (value) => number` — optional O(1) size estimator; otherwise defaults to `node:v8.serialize(value).byteLength`.

Both bounds can be set together; whichever is hit first triggers LRU eviction. `get()` promotes the touched key to the end of insertion order. `set()` drops the oldest entries until both bounds are satisfied, with a **soft cap**: the just-written entry is never evicted even if its size alone exceeds `maxBytes`, so consumers never silently lose a write.

**Default stays unbounded** so existing callers are unaffected. The Redis engine ignores both — use Redis `maxmemory` + `maxmemory-policy` there.

Why `v8.serialize` as the default sizer:
- Handles circular references (mongoose `populate` query results can carry parent back-refs, and the memory engine stores by reference today — any JSON-based sizer would throw on those).
- One C++ call per `set`, no recursive JS walk.
- `node:v8` is available on Node, Bun, and Deno — same runtime scope as the existing `node:crypto` import in `src/key.ts`, so this adds no new runtime lock-in.

### 2. Reject non-positive TTLs at `Cache.set`

`ms('0 seconds')` → `0`. `ms('-1 minute')` → `-60000`. Previously these flowed through to `engine.set`:
- On Redis: `setex key 0 value` errors with `ERR invalid expire time in 'setex' command`, which was silently forwarded to `onError` as noise.
- On memory: produced a write with an already-expired `expiresAt`, deleted on the next `get`. Wasted work.

`Cache.set` now short-circuits any `actualTTL` that is `NaN` or `<= 0`, logging under debug mode. Fixes both engines at one site.

### 3. Regression test for `EJSON.parse` prototype pollution

`bson.EJSON.parse` is safe today — `__proto__` lands as an own property on the result object and cannot walk up to `Object.prototype` — but we rely on that property every time we rehydrate an attacker-controllable Redis payload into `Model.hydrate`. A regression test locks the safe behavior in so a future `bson` release that reintroduces manual property assignment during reviver handling fails loudly here rather than silently poisoning consumers.

Probe:
```
Before parse: ({}).polluted = undefined
After  parse: ({}).polluted = undefined
Object.prototype.polluted = undefined
```

## Test plan

- [x] `tests/memory-bound.test.ts` — 14 tests covering entry cap, byte cap, combined bounds, `totalBytes` tracking across set/del/clear/replace/expire, LRU promotion via `get()`, soft cap on oversized entries, `Cache → MemoryCacheEngine` wiring for both options, default `v8.serialize` sizer, custom `sizeCalculation` callback.
- [x] `tests/cache-ttl-guard.test.ts` — 6 tests: zero/negative/NaN TTLs all skip `engine.set`; healthy TTL still writes; `defaultTTL` fallback; end-to-end memory round-trip.
- [x] `tests/proto-pollution.test.ts` — 4 tests: top-level `__proto__`, nested `__proto__`, `constructor.prototype` path, and a full Redis-rehydration mirror.
- [x] `npm run biome` clean.
- [x] `npm run type:check` and `npm run type:check:tests` clean.
- [x] Full unit sweep green: 120/120 across 14 files (including `tests/cache-memory.test.ts` against `mongodb-memory-server`).
- [ ] CI: full matrix (mongoose 6.12.2 / 7.6.4 / 8.23.0 / 9.4.1), CodeQL, Sonar, Socket, Snyk.